### PR TITLE
Update installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ The goal is a severless WordPress environment for quick tests.
 *Installing*
 
 ```
-go get github.com/rheinardkorf/portable-wp
-cd $GOPATH/src/github.com/rheinardkorf/portable-wp/
-go install ./...
+go get github.com/rheinardkorf/portable-wp/cmd/pwp
 ```
 
 Make sure that $GOPATH/bin is in your paths. You can then run


### PR DESCRIPTION
Since you commits the vendor packages to GitHub you don't need to run a `go install` locally instead you can just `go get` the cmd package and it will install it self as a binary package.