### PR TITLE
Defer file closure results in too many files remaining open.

### DIFF
--- a/cmd/pwp/main.go
+++ b/cmd/pwp/main.go
@@ -127,6 +127,7 @@ func runServer(settings *siteSettings) error {
 	}
 
 	serve := exec.Command("php", "-S", fmt.Sprintf("%s:%s", *settings.host, *settings.port), "-t", *settings.path, *settings.path+"/router.php")
+	browse := exec.Command("open", fmt.Sprintf("http://%s:%s", *settings.host, *settings.port) );
 	fmt.Println("Starting built-in PHP server.")
 	fmt.Printf("http://%s:%s\n", *settings.host, *settings.port)
 	fmt.Println("Press Ctl-C to exit.")
@@ -134,7 +135,8 @@ func runServer(settings *siteSettings) error {
 	if err != nil {
 		logger.Fatal(err)
 	}
-
+	// No need to catch errors in case this is not supported (OSX)
+	browse.Start()
 	err = serve.Wait()
 	log.Printf("Command finished with error: %v", err)
 

--- a/cmd/pwp/main.go
+++ b/cmd/pwp/main.go
@@ -224,19 +224,21 @@ func extractWordPress(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer fileReader.Close()
 
 		// Get the destination...
 		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 		if err != nil {
 			return err
 		}
-		defer targetFile.Close()
-
+		
 		// Copy!
 		if _, err := io.Copy(targetFile, fileReader); err != nil {
 			return err
 		}
+		
+		// Close files.
+		fileReader.Close()
+		targetFile.Close()
 	}
 
 	os.Remove(src)

--- a/cmd/pwp/main.go
+++ b/cmd/pwp/main.go
@@ -85,34 +85,34 @@ func setup(settings *siteSettings) error {
 	if _, err := os.Stat(*settings.path); os.IsNotExist(err) {
 		// Download WordPress.
 		if err := downloadWordPress(WordPressDownload, *settings.path); err != nil {
-			return errors.New(fmt.Sprintf("could not download WordPress: %s", err));
+			return errors.New(fmt.Sprintf("could not download WordPress: %s", err))
 		}
 
 		// Extract WordPress.
 		if err := extractWordPress(*settings.path+".zip", *settings.path); err != nil {
-			return errors.New(fmt.Sprintf("could not extract WordPress: %s", err));
+			return errors.New(fmt.Sprintf("could not extract WordPress: %s", err))
 		}
 
 		pluginPath := *settings.path + "/wp-content/plugins"
 
 		// Download SQLite plugin.
 		if err := downloadSqlLitePlugin(SQLitePlugin, pluginPath+"/plugin.zip"); err != nil {
-			return errors.New(fmt.Sprintf("could not download SQLite plugin: %s", err));
+			return errors.New(fmt.Sprintf("could not download SQLite plugin: %s", err))
 		}
 
 		// Extract SQLite plugin.
 		if err := extractSqlLitePlugin(pluginPath + "/plugin.zip"); err != nil {
-			return errors.New(fmt.Sprintf("could not extract SQLite plugin: %s", err));
+			return errors.New(fmt.Sprintf("could not extract SQLite plugin: %s", err))
 		}
 
 		// Config WordPress.
 		if err := createConfig(settings); err != nil {
-			return errors.New(fmt.Sprintf("could not create WordPress config: %s", err));
+			return errors.New(fmt.Sprintf("could not create WordPress config: %s", err))
 		}
 
 		// Router file.
 		if err := createRouter(settings); err != nil {
-			return errors.New(fmt.Sprintf("router file fail: %s", err));
+			return errors.New(fmt.Sprintf("router file fail: %s", err))
 		}
 	}
 	return nil
@@ -127,7 +127,7 @@ func runServer(settings *siteSettings) error {
 	}
 
 	serve := exec.Command("php", "-S", fmt.Sprintf("%s:%s", *settings.host, *settings.port), "-t", *settings.path, *settings.path+"/router.php")
-	browse := exec.Command("open", fmt.Sprintf("http://%s:%s", *settings.host, *settings.port) );
+	browse := exec.Command("open", fmt.Sprintf("http://%s:%s", *settings.host, *settings.port) )
 	fmt.Println("Starting built-in PHP server.")
 	fmt.Printf("http://%s:%s\n", *settings.host, *settings.port)
 	fmt.Println("Press Ctl-C to exit.")

--- a/cmd/pwp/main.go
+++ b/cmd/pwp/main.go
@@ -29,8 +29,8 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-const WordPressDownload string = "https://wordpress.org/latest.zip"
-const SQLitePlugin string = "https://downloads.wordpress.org/plugin/sqlite-integration.zip"
+const WordPressDownload = "https://wordpress.org/latest.zip"
+const SQLitePlugin = "https://downloads.wordpress.org/plugin/sqlite-integration.zip"
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
@@ -38,7 +38,7 @@ const (
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
-var logger *log.Logger = log.New(os.Stdout, "pwp:", log.LstdFlags)
+var logger = log.New(os.Stdout, "pwp:", log.LstdFlags)
 
 // siteSettings is contains the values of the command line flags or defaults.
 type siteSettings struct {


### PR DESCRIPTION
Close each file after copying to free up memory.

and a bonus: open the URL in the default browser.